### PR TITLE
Fix nginx: remove must-revalidate from gzip_proxied to prevent startu…

### DIFF
--- a/.docker/nginx.conf
+++ b/.docker/nginx.conf
@@ -8,7 +8,7 @@ server {
     gzip on;
     gzip_vary on;
     gzip_min_length 1024;
-    gzip_proxied expired no-cache no-store private must-revalidate auth;
+    gzip_proxied expired no-cache no-store private auth;
     gzip_types
         text/plain
         text/css


### PR DESCRIPTION
# Pull Request

## 📋 Description

Invalid value "must-revalidate" in /etc/nginx/conf.d/nginx.conf preventing evolution manager v2 startup locally.

Line changed from:
gzip_proxied expired no-cache no-store private must-revalidate auth;

To:
gzip_proxied expired no-cache no-store private auth;

The container now starts correctly.

The nginx documentation supports the change (http://nginx.org/en/docs/http/ngx_http_gzip_module.html#gzip_proxied):

Syntax:	gzip_proxied off | expired | no-cache | no-store | private | no_last_modified | no_etag | auth | any ...;
Default:	gzip_proxied off;
Context:	http, server, location

## 🔗 Related Issues

N/A

- Fixes #

## 🧪 Type of Change

<!-- Mark the relevant option with an "x" -->

- [ X ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI changes
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] 🔧 Build/CI changes
- [ ] 🧪 Tests

## 🧪 Testing

<!-- Describe the tests you ran and how to reproduce them -->

### Test Environment
- [X] Local development
- [ ] Staging environment
- [ ] Production-like environment

### Test Cases
- [ ] Unit tests pass
- [ ] Integration tests pass
- [X] Manual testing completed
- [ ] Cross-browser testing (if applicable)
- [ ] Mobile testing (if applicable)

### Test Instructions
<!-- Provide step-by-step instructions for testing this PR -->

1. Pull the container image and run it on Docker:
services:
  frontend:
    container_name: evolution_frontend
    image: evoapicloud/evolution-manager:latest
    restart: always
    ports:
      - "3000:80"
    networks:
      - evolution-net

## 📸 Screenshots
N/A

### Before
N/A

### After
N/A

## ✅ Checklist

<!-- Mark completed items with an "x" -->

### Code Quality
- [X] My code follows the project's style guidelines
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings or errors
- [  ] I have run `npm run lint` and fixed any issues

### Testing
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested the changes in multiple browsers (if applicable)
- [ ] I have tested the changes on mobile devices (if applicable)

### Documentation
- [ ] I have made corresponding changes to the documentation
- [ ] I have updated the README.md if necessary
- [ ] I have added/updated JSDoc comments for new functions
- [ ] I have updated type definitions if necessary

### Internationalization
- [ ] I have added translations for new text strings
- [ ] I have tested the changes in different languages (if applicable)

### Breaking Changes
- [ ] This PR introduces breaking changes
- [ ] I have documented the breaking changes in the description
- [ ] I have updated the migration guide (if applicable)

## 🔄 Migration Guide

N/A

### Before
```typescript
// Old code example
```

### After
```typescript
// New code example
```

## 📝 Additional Notes

N/A

## 🤝 Reviewer Guidelines

<!-- Guidelines for reviewers -->

### Focus Areas
- [ ] Code logic and correctness
- [ ] Performance implications
- [ ] Security considerations
- [ ] User experience
- [ ] Accessibility
- [ ] Browser compatibility

### Testing Checklist for Reviewers
- [ ] Pull and test the branch locally
- [ ] Verify the fix/feature works as described
- [ ] Check for edge cases
- [ ] Verify no regressions in existing functionality

---

**Thank you for contributing to Evolution Manager! 🚀**

## Summary by Sourcery

Bug Fixes:
- Remove invalid "must-revalidate" value from gzip_proxied in nginx.conf to allow the container to start correctly