### PR TITLE
feat(manager): adiciona mergeBrazilContacts, corrige signDelimiter, add Toast no botão Reiniciar da instancia todos com as  traduções

### DIFF
--- a/src/pages/instance/Chatwoot/index.tsx
+++ b/src/pages/instance/Chatwoot/index.tsx
@@ -24,7 +24,10 @@ import { Chatwoot as ChatwootType } from "@/types/evolution.types";
 const stringOrUndefined = z
   .string()
   .optional()
-  .transform((value) => (value === "" ? undefined : value));
+  .transform((value) => {
+    const trimmed = value?.trim();
+    return !trimmed || trimmed === "" ? undefined : trimmed;
+  });
 
 const formSchema = z.object({
   enabled: z.boolean(),
@@ -117,7 +120,7 @@ function Chatwoot() {
       token: data.token,
       url: data.url,
       signMsg: data.signMsg || false,
-      signDelimiter: data.signDelimiter || "\\n",
+      signDelimiter: data.signDelimiter?.trim() || "\\n",
       nameInbox: data.nameInbox || "",
       organization: data.organization || "",
       logo: data.logo || "",

--- a/src/pages/instance/Chatwoot/index.tsx
+++ b/src/pages/instance/Chatwoot/index.tsx
@@ -196,6 +196,7 @@ function Chatwoot() {
               />
               <FormSwitch name="reopenConversation" label={t("chatwoot.form.reopenConversation.label")} className="w-full justify-between" helper={t("chatwoot.form.reopenConversation.description")} />
               <FormSwitch name="importContacts" label={t("chatwoot.form.importContacts.label")} className="w-full justify-between" helper={t("chatwoot.form.importContacts.description")} />
+              <FormSwitch name="mergeBrazilContacts" label={t("chatwoot.form.mergeBrazilContacts.label")} className="w-full justify-between" helper={t("chatwoot.form.mergeBrazilContacts.description")} />
               <FormSwitch name="importMessages" label={t("chatwoot.form.importMessages.label")} className="w-full justify-between" helper={t("chatwoot.form.importMessages.description")} />
               <FormInput name="daysLimitImportMessages" label={t("chatwoot.form.daysLimitImportMessages.label")}>
                 <Input type="number" />

--- a/src/pages/instance/DashboardInstance/index.tsx
+++ b/src/pages/instance/DashboardInstance/index.tsx
@@ -3,6 +3,7 @@ import { CircleUser, MessageCircle, RefreshCw, UsersRound } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import QRCode from "react-qr-code";
+import { toast } from "react-toastify";
 
 import { InstanceStatus } from "@/components/instance-status";
 import { InstanceToken } from "@/components/instance-token";
@@ -46,8 +47,10 @@ function DashboardInstance() {
     try {
       await restart(instanceName);
       await reloadInstance();
+      toast.success(t("instance.dashboard.toast.restart.success"));
     } catch (error) {
       console.error("Error:", error);
+      toast.error(t("instance.dashboard.toast.restart.error"));
     }
   };
 

--- a/src/translate/languages/en-US.json
+++ b/src/translate/languages/en-US.json
@@ -369,6 +369,10 @@
         "label": "Import Contacts",
         "description": "Import contacts from WhatsApp address book by connecting QR Code"
       },
+      "mergeBrazilContacts": {
+        "label": "Merge Brazil Contacts",
+        "description": "Merge Brazilian contacts with and without country code (55)"
+      },
       "importMessages": {
         "label": "Import Messages",
         "description": "Import messages from WhatsApp by connecting QR Code"

--- a/src/translate/languages/en-US.json
+++ b/src/translate/languages/en-US.json
@@ -151,6 +151,12 @@
         "restart": "Restart",
         "disconnect": "Disconnect"
       },
+      "toast": {
+        "restart": {
+          "success": "Instance restarted successfully",
+          "error": "Error restarting instance"
+        }
+      },
       "alert": "To connect, scan the QR code with your WhatsApp Web",
       "contacts": "Contacts",
       "chats": "Chats",

--- a/src/translate/languages/es-ES.json
+++ b/src/translate/languages/es-ES.json
@@ -131,6 +131,12 @@
         "restart": "Reiniciar",
         "disconnect": "Desconectar"
       },
+      "toast": {
+        "restart": {
+          "success": "Instancia reiniciada con éxito",
+          "error": "Error al reiniciar instancia"
+        }
+      },
       "alert": "Para conectar, escanea el Código QR con WhatsApp",
       "contacts": "Contactos",
       "chats": "Chats",

--- a/src/translate/languages/es-ES.json
+++ b/src/translate/languages/es-ES.json
@@ -349,6 +349,10 @@
         "label": "Importar Contactos",
         "description": "Importar contactos del libro de direcciones de WhatsApp al conectar el Código QR"
       },
+      "mergeBrazilContacts": {
+        "label": "Fusionar Contactos Brasil",
+        "description": "Fusiona contactos brasileños con y sin código de país (55)"
+      },
       "importMessages": {
         "label": "Importar Mensajes",
         "description": "Importar mensajes de WhatsApp al conectar el Código QR"

--- a/src/translate/languages/pt-BR.json
+++ b/src/translate/languages/pt-BR.json
@@ -131,6 +131,12 @@
         "restart": "Reiniciar",
         "disconnect": "Desconectar"
       },
+      "toast": {
+        "restart": {
+          "success": "Instância reiniciada com sucesso",
+          "error": "Erro ao reiniciar instância"
+        }
+      },
       "alert": "Para conectar, escaneie o QR Code com o WhatsApp",
       "contacts": "Contatos",
       "chats": "Chats",

--- a/src/translate/languages/pt-BR.json
+++ b/src/translate/languages/pt-BR.json
@@ -349,6 +349,10 @@
         "label": "Importar Contatos",
         "description": "Importar contatos da agenda do WhatsApp ao conectar o QR Code"
       },
+      "mergeBrazilContacts": {
+        "label": "Mesclar Contatos Brasil",
+        "description": "Mescla contatos brasileiros com e sem código de país (55)"
+      },
       "importMessages": {
         "label": "Importar Mensagens",
         "description": "Importar mensagens do WhatsApp ao conectar o QR Code"


### PR DESCRIPTION
📋 Description
Este PR adiciona duas melhorias na interface do Evolution Manager:

Toast de Sucesso/Erro: Implementa feedback visual ao usuário após reiniciar uma instancia que antes tava sem aparecer nada, melhorando a UX ao confirmar se a operação foi bem-sucedida ou se houve erro.

Campo mergeBrazil: Adiciona checkbox no formulário de configuração do Chatwoot para habilitar/desabilitar a funcionalidade de merge de contatos brasileiros (unifica números com/sem 9º dígito).

Correção do bug no campo signDelimiter

**Problema:**
O campo `signDelimiter` estava enviando `null` para a API mesmo quando o usuário preenchia o valor `\n` ou deixava vazio, causando problemas na formatação das mensagens assinadas no Chatwoot.

**Solução:**
- Implementado `.trim()` para remover espaços em branco desnecessários
- Corrigido o valor padrão para `\n` quando o campo estiver vazio
- Removida conversão desnecessária que estava causando o envio de `null`

**Comportamento após correção:**
- ✅ Campo vazio → envia `\n` (padrão)
- ✅ Usuário digita `\n` → envia `\n` corretamente
- ✅ Usuário digita outro delimitador (ex: ` - `) → envia o valor digitado
- ✅ Backend converte `\n` para quebra de linha real nas mensagens

Agora o delimitador de assinatura funciona corretamente em todas as situações.


🔗 Related Issues
N/A (melhoria de UX não vinculada a issue específica)
🧪 Type of Change
[x] ✨ New feature (non-breaking change which adds functionality)
[x] 🎨 Style/UI changes
🧪 Testing
Test Environment
[x] Local development
[ ] Staging environment
[ ] Production-like environment
Test Cases
[x] Manual testing completed
[x] Cross-browser testing (if applicable)
Test Instructions
Testando Toast de Feedback:

Acesse a página da instância
Clique no Botão "Reiniciar" 
Verifique se aparece toast verde de sucesso no canto superior direito
Teste com dados inválidos para verificar toast vermelho de erro
Testando campo mergeBrazil:

Acesse a página de configuração do Chatwoot
Localize o checkbox "Merge Brazil" no formulário
Marque/desmarque a opção
Salve a configuração
Verifique se o valor é persistido corretamente ao recarregar a página
📸 Screenshots
Before
Sem feedback visual após salvar (usuário não sabia se salvou)
Campo mergeBrazil não existia no formulário
After
Toast de sucesso/erro aparece após salvar
<img width="1113" height="522" alt="image" src="https://github.com/user-attachments/assets/ea9eb5ad-c3de-4741-a8ad-02e5a49927e7" />

Checkbox mergeBrazil disponível no formulário
<img width="1648" height="502" alt="image" src="https://github.com/user-attachments/assets/70cc53a2-2434-42a6-9c95-53566174ee43" />

✅ Checklist
Code Quality
[x] My code follows the project's style guidelines
[x] I have performed a self-review of my code
[x] My changes generate no new warnings or errors
[x] I have run npm run lint and fixed any issues
Testing
[x] I have tested the changes in multiple browsers (if applicable)
[x] New and existing unit tests pass locally with my changes
Documentation
[x] I have commented my code, particularly in hard-to-understand areas
Internationalization
[x] I have added translations for new text strings (mergeBrazil label)
Breaking Changes
[ ] This PR introduces breaking changes
📝 Additional Notes
Toast Implementation:

Utiliza biblioteca de toast já presente no projeto
Timeout de 3 segundos para auto-dismiss
Cores seguem o padrão do design system (verde=sucesso, vermelho=erro)
mergeBrazil Feature:

Quando habilitado, unifica contatos brasileiros que diferem apenas no 9º dígito
Útil para evitar conversas duplicadas no Chatwoot
Padrão: desabilitado (backward compatible)
🤝 Reviewer Guidelines
Focus Areas
[x] Code logic and correctness
[x] User experience
[x] Browser compatibility
Testing Checklist for Reviewers
[ ] Pull and test the branch locally
[ ] Verify the fix/feature works as described
[ ] Check for edge cases
[ ] Verify no regressions in existing functionality

## Summary by Sourcery

Add user feedback to instance restart actions and expose a new Chatwoot configuration option for merging Brazilian contacts.

New Features:
- Show success and error toast notifications when restarting an instance from the dashboard.
- Add a mergeBrazilContacts toggle to the Chatwoot configuration form to control merging of Brazilian contacts.