### PR TITLE
Fix/contact message null crash

### DIFF
--- a/src/pages/instance/Chat/messages.tsx
+++ b/src/pages/instance/Chat/messages.tsx
@@ -515,14 +515,14 @@ function Messages({ textareaRef, handleTextareaChange, textareaHeight, lastMessa
 
   // Group messages by date
   const groupedMessages = useMemo(() => {
-  if (!allMessages) return [];
+    if (!allMessages) return [];
 
-  // Sort messages by timestamp first
-  const sortedMessages = [...allMessages].sort((a, b) => {
-    const aTime = getMessageTimestamp(a).getTime();
-    const bTime = getMessageTimestamp(b).getTime();
-    return aTime - bTime;
-  });
+    // Sort messages by timestamp first
+    const sortedMessages = [...allMessages].sort((a, b) => {
+      const aTime = getMessageTimestamp(a).getTime();
+      const bTime = getMessageTimestamp(b).getTime();
+      return aTime - bTime;
+    });
 
     const grouped: { date: string; messages: Message[] }[] = [];
     let currentDate = "";

--- a/src/pages/instance/Chat/messages.tsx
+++ b/src/pages/instance/Chat/messages.tsx
@@ -1,6 +1,7 @@
 import { DropdownMenu, DropdownMenuTrigger } from "@radix-ui/react-dropdown-menu";
 import { ArrowRightIcon, ChevronDownIcon, SparkleIcon, User, ZapIcon } from "lucide-react";
 import { RefObject, useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { useParams } from "react-router-dom";
 
 import { Button } from "@/components/ui/button";
@@ -139,6 +140,17 @@ const getMessageText = (messageObj: any): string => {
 
 // Component to render different message types based on messageType
 const MessageContent = ({ message }: { message: Message }) => {
+  const { t } = useTranslation();
+
+  // Early return for invalid messages
+  if (!message?.message) {
+    return (
+      <div className="text-xs text-muted-foreground bg-muted p-2 rounded max-w-xs">
+        {t("chat.message.invalidOrUnsupported")}
+      </div>
+    );
+  }
+
   const messageType = message.messageType as string;
 
   switch (messageType) {
@@ -503,14 +515,14 @@ function Messages({ textareaRef, handleTextareaChange, textareaHeight, lastMessa
 
   // Group messages by date
   const groupedMessages = useMemo(() => {
-    if (!allMessages) return [];
+  if (!allMessages) return [];
 
-    // Sort messages by timestamp first
-    const sortedMessages = [...allMessages].sort((a, b) => {
-      const aTime = getMessageTimestamp(a).getTime();
-      const bTime = getMessageTimestamp(b).getTime();
-      return aTime - bTime;
-    });
+  // Sort messages by timestamp first
+  const sortedMessages = [...allMessages].sort((a, b) => {
+    const aTime = getMessageTimestamp(a).getTime();
+    const bTime = getMessageTimestamp(b).getTime();
+    return aTime - bTime;
+  });
 
     const grouped: { date: string; messages: Message[] }[] = [];
     let currentDate = "";

--- a/src/translate/languages/en-US.json
+++ b/src/translate/languages/en-US.json
@@ -46,6 +46,9 @@
     }
   },
   "chat": {
+    "message": {
+      "invalidOrUnsupported": "Invalid or unsupported message"
+    },
     "media": {
       "attach": "Attach file",
       "document": "Document",

--- a/src/translate/languages/es-ES.json
+++ b/src/translate/languages/es-ES.json
@@ -45,6 +45,11 @@
       "french": "Francés"
     }
   },
+  "chat": {
+    "message": {
+      "invalidOrUnsupported": "Mensaje inválido o no soportado"
+    }
+  },
   "sidebar": {
     "dashboard": "Visión General",
     "configurations": "Configuraciones",

--- a/src/translate/languages/fr-FR.json
+++ b/src/translate/languages/fr-FR.json
@@ -44,6 +44,11 @@
       "french": "Français"
     }
   },
+  "chat": {
+    "message": {
+      "invalidOrUnsupported": "Message invalide ou non pris en charge"
+    }
+  },
   "sidebar": {
     "dashboard": "Vue d'ensemble",
     "configurations": "Configurations",

--- a/src/translate/languages/pt-BR.json
+++ b/src/translate/languages/pt-BR.json
@@ -45,6 +45,11 @@
       "french": "Francês"
     }
   },
+  "chat": {
+    "message": {
+      "invalidOrUnsupported": "Mensagem inválida ou não suportada"
+    }
+  },
   "sidebar": {
     "dashboard": "Visão Geral",
     "configurations": "Configurações",


### PR DESCRIPTION
# Pull Request

## 📋 Description

This PR fixes a frontend crash in the chat UI caused by malformed or incomplete message payloads coming from the backend.

In production, some messages arrive with `message` set to `null` (or missing nested fields), while the UI assumed the presence of properties like `contactMessage`, resulting in a runtime error:

```
Cannot read properties of null (reading 'contactMessage')
```

The fix adds proper null-guards and safe fallbacks when rendering messages, preventing the entire conversation view from breaking.


> Note: This is my first contribution fixing a bug in this repository.
> While I cannot guarantee that this covers all possible edge cases, the change successfully reproduces and fixes the reported crash in my local environment. The goal of this PR is to prevent the UI from breaking when receiving malformed or null message payloads, as observed in production.
> Feedback and suggestions are very welcome.

---

## 🔗 Related Issues

* Fixes crash when opening conversations containing contact messages with null payloads
* Related to production runtime error: `Cannot read properties of null (reading 'contactMessage')`

---

## 🧪 Type of Change

* [x] 🐛 Bug fix (non-breaking change which fixes an issue)

---

## 🧪 Testing

### Test Environment

* [x] Local development

### Test Cases

* [ ] Unit tests pass (no tests defined in the project)
* [ ] Integration tests pass (not available)
* [x] Manual testing completed
* [ ] Cross-browser testing (not applicable)
* [ ] Mobile testing (not applicable)

### Test Instructions

1. Run the project locally.
2. Open a conversation containing a contact message with malformed or null payload.
3. Verify that the chat renders without crashing and shows a safe fallback for the message.

---

## 📸 Screenshots

<img width="1432" height="729" alt="Captura de Tela 2026-01-08 às 15 31 04" src="https://github.com/user-attachments/assets/8a7acef5-ebfb-422b-a10c-4be4b7be6a56" />

### Before

* Application crashes with:

  ```
  Cannot read properties of null (reading 'contactMessage')
  ```

### After

* Conversation opens normally.
* Message renders using a safe fallback without breaking the UI.

---

## ✅ Checklist

### Code Quality

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [x] My changes generate no new errors
* [x] I have run `npm run lint` and fixed blocking issues (warnings only, pre-existing)

### Testing

* [x] I have manually tested the fix locally
* [x] The fix prevents the reported crash
* [ ] Automated tests added (not applicable — no test setup exists)

### Documentation

* [ ] Documentation update not required (no public API changes)

### Internationalization

* [ ] Not applicable

### Breaking Changes

* [ ] This PR introduces no breaking changes

---

## 🔄 Migration Guide

Not applicable — no API or behavioral changes for consumers.

---

## 📝 Additional Notes

This issue only surfaced in production due to inconsistent message payloads.
The fix ensures the UI is resilient to malformed messages without assuming backend correctness.

---

## 🤝 Reviewer Guidelines

### Focus Areas

* [x] Code logic and correctness
* [x] User experience (no more hard crashes)
* [x] Edge case handling for malformed messages

### Testing Checklist for Reviewers

* [ ] Pull and run the project locally
* [ ] Open a conversation with contact messages
* [ ] Verify the UI no longer crashes

## Summary by Sourcery

Handle null or malformed chat messages without crashing the conversation view.

Bug Fixes:
- Prevent chat UI from crashing when rendering messages with null or missing message payloads by handling invalid message objects early.

Enhancements:
- Display a generic fallback text for invalid or unsupported chat messages using localized translations across supported languages.