### PR TITLE
Fix: invalid value "must-revalidate"

### DIFF
--- a/.docker/nginx.conf
+++ b/.docker/nginx.conf
@@ -8,7 +8,7 @@ server {
     gzip on;
     gzip_vary on;
     gzip_min_length 1024;
-    gzip_proxied expired no-cache no-store private must-revalidate auth;
+    gzip_proxied expired no-cache no-store private auth;
     gzip_types
         text/plain
         text/css


### PR DESCRIPTION
# Pull Request

## 📋 Description

Fix a critical Nginx configuration error in `docker/nginx.conf`. The `gzip_proxied` directive was using an invalid parameter `must-revalidate`, which caused the Nginx master process to fail during startup.

**Error logs observed:**
`evolution-manager | 2026/03/11 03:40:07 [emerg] 7#7: invalid value "must-revalidate" in /etc/nginx/conf.d/nginx.conf:11`
`evolution-manager | nginx: [emerg] invalid value "must-revalidate" in /etc/nginx/conf.d/nginx.conf:11`

**Root Cause:**
According to Nginx official documentation, `must-revalidate` is a valid value for the `Cache-Control` HTTP header, but it is **not** a valid parameter for the `gzip_proxied` directive. This PR removes the invalid parameter to allow the container to start successfully.

## 🔗 Related Issues

- Fixes the container crash loop when deploying with the provided Dockerfile.

## 🧪 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update

## 🧪 Testing

### Test Environment
- [x] Local development (Docker Engine on Linux)
- [x] Production-like environment

### Test Cases
- [x] Manual testing completed: Confirmed the container status is `Up` and Nginx starts without errors.
- [x] Verified that Gzip compression still functions with the remaining valid parameters.

### Test Instructions

1. Build the image: `docker build -t evolution-manager:test .`
2. Run the container: `docker run --rm evolution-manager:test`
3. Check the output: Nginx should start normally instead of exiting with `code 1`.

## ✅ Checklist

### Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors

### Testing
- [x] I have tested the changes and proved my fix is effective.

## 📝 Additional Notes

The valid parameters for `gzip_proxied` are: `off`, `expired`, `no-cache`, `no-store`, `private`, `no_last_modified`, `no_etag`, `auth`, or `any`. 

---
**Thank you for contributing to Evolution Manager! 🚀**

## Summary by Sourcery

Bug Fixes:
- Remove the unsupported must-revalidate value from the gzip_proxied directive in the Docker Nginx configuration to allow Nginx to start successfully.