### PR TITLE
fix: broken logo & favicon (assets point to dead evolution-api.com URLs)

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/png" href="https://evolution-api.com/files/evo/favicon.svg" />
+    <link rel="icon" type="image/png" href="/assets/images/evolution-logo.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Evolution Manager</title>
   </head>

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -44,8 +44,8 @@ function SidebarShell({ children, footer }: { children: React.ReactNode; footer?
   const { theme } = useTheme();
   const logoSrc =
     theme === "dark"
-      ? "https://evolution-api.com/files/evo/evolution-logo-white.svg"
-      : "https://evolution-api.com/files/evo/evolution-logo.svg";
+      ? "/assets/images/evolution-logo.png"
+      : "/assets/images/evolution-logo.png";
 
   return (
     <aside className="hidden md:flex bg-sidebar text-sidebar-foreground flex-col w-56 border-r border-sidebar-border">

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -1,4 +1,5 @@
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@evoapi/design-system/collapsible";
+import { LOGO_SRC } from "@/lib/constants";
 import {
   ChevronDown,
   CircleHelp,
@@ -13,7 +14,6 @@ import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { NavLink, useLocation } from "react-router-dom";
 
-import { useTheme } from "@/components/theme-provider";
 import { useInstance } from "@/contexts/InstanceContext";
 
 import { FEATURES, FeatureKey, isFeatureEnabled } from "@/lib/provider/features";
@@ -41,11 +41,7 @@ type Menu = MenuLeaf | MenuGroup;
 
 function SidebarShell({ children, footer }: { children: React.ReactNode; footer?: React.ReactNode }) {
   const currentYear = new Date().getFullYear();
-  const { theme } = useTheme();
-  const logoSrc =
-    theme === "dark"
-      ? "/assets/images/evolution-logo.png"
-      : "/assets/images/evolution-logo.png";
+  const logoSrc = LOGO_SRC;
 
   return (
     <aside className="hidden md:flex bg-sidebar text-sidebar-foreground flex-col w-56 border-r border-sidebar-border">

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,1 @@
+export const LOGO_SRC = "/assets/images/evolution-logo.png";

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,15 +1,14 @@
 import { Button } from "@evoapi/design-system/button";
+import { LOGO_SRC } from "@/lib/constants";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@evoapi/design-system/card";
 import { Badge } from "@evoapi/design-system/badge";
 import { ArrowRight, Github, Globe, Mail, Shield } from "lucide-react";
 import { useNavigate } from "react-router-dom";
-import { useTheme } from "@/components/theme-provider";
 import { ModeToggle } from "@/components/mode-toggle";
 import { LanguageToggle } from "@/components/language-toggle";
 
 export default function Home() {
   const navigate = useNavigate();
-  const { theme } = useTheme();
 
   const handleGoToManager = () => {
     navigate("/manager");
@@ -21,7 +20,7 @@ export default function Home() {
       <header className="flex items-center justify-between px-4 py-2">
         <div className="flex items-center">
           <img
-            src={theme === "dark" ? "/assets/images/evolution-logo.png" : "/assets/images/evolution-logo.png"}
+            src={LOGO_SRC}
             alt="Evolution API Logo"
             className="h-8"
           />
@@ -38,7 +37,7 @@ export default function Home() {
           <div className="text-center mb-12">
             <div className="flex items-center justify-center mb-6">
               <img
-                src={theme === "dark" ? "/assets/images/evolution-logo.png" : "/assets/images/evolution-logo.png"}
+                src={LOGO_SRC}
                 alt="Evolution Manager Logo"
                 className="h-10"
               />

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -21,7 +21,7 @@ export default function Home() {
       <header className="flex items-center justify-between px-4 py-2">
         <div className="flex items-center">
           <img
-            src={theme === "dark" ? "https://evolution-api.com/files/evo/evolution-logo-white.svg" : "https://evolution-api.com/files/evo/evolution-logo.svg"}
+            src={theme === "dark" ? "/assets/images/evolution-logo.png" : "/assets/images/evolution-logo.png"}
             alt="Evolution API Logo"
             className="h-8"
           />
@@ -38,7 +38,7 @@ export default function Home() {
           <div className="text-center mb-12">
             <div className="flex items-center justify-center mb-6">
               <img
-                src={theme === "dark" ? "https://evolution-api.com/files/evo/evolution-logo-white.svg" : "https://evolution-api.com/files/evo/evolution-logo.svg"}
+                src={theme === "dark" ? "/assets/images/evolution-logo.png" : "/assets/images/evolution-logo.png"}
                 alt="Evolution Manager Logo"
                 className="h-10"
               />

--- a/src/pages/Login/LicenseCallback.tsx
+++ b/src/pages/Login/LicenseCallback.tsx
@@ -28,8 +28,8 @@ function LicenseCallback() {
 
   const logoSrc =
     theme === "dark"
-      ? "https://evolution-api.com/files/evo/evolution-logo-white.svg"
-      : "https://evolution-api.com/files/evo/evolution-logo.svg";
+      ? "/assets/images/evolution-logo.png"
+      : "/assets/images/evolution-logo.png";
 
   const doActivate = useCallback(async () => {
     setState("activating");

--- a/src/pages/Login/LicenseCallback.tsx
+++ b/src/pages/Login/LicenseCallback.tsx
@@ -4,12 +4,11 @@
 // redirects back to /manager (or back to /manager/login on failure).
 
 import { Button } from "@evoapi/design-system/button";
+import { LOGO_SRC } from "@/lib/constants";
 import { CheckCircle, Loader2, XCircle } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useSearchParams } from "react-router-dom";
-
-import { useTheme } from "@/components/theme-provider";
 
 import { activateLicense } from "@/lib/queries/license/license";
 import { getToken, TOKEN_ID } from "@/lib/queries/token";
@@ -18,7 +17,6 @@ type State = "activating" | "success" | "error";
 
 function LicenseCallback() {
   const { t } = useTranslation();
-  const { theme } = useTheme();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const code = searchParams.get("code") ?? "";
@@ -26,10 +24,7 @@ function LicenseCallback() {
   const [state, setState] = useState<State>("activating");
   const [errorMessage, setErrorMessage] = useState("");
 
-  const logoSrc =
-    theme === "dark"
-      ? "/assets/images/evolution-logo.png"
-      : "/assets/images/evolution-logo.png";
+  const logoSrc = LOGO_SRC;
 
   const doActivate = useCallback(async () => {
     setState("activating");

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -34,8 +34,8 @@ function Login() {
   const [submitting, setSubmitting] = useState(false);
   const logoSrc =
     theme === "dark"
-      ? "https://evolution-api.com/files/evo/evolution-logo-white.svg"
-      : "https://evolution-api.com/files/evo/evolution-logo.svg";
+      ? "/assets/images/evolution-logo.png"
+      : "/assets/images/evolution-logo.png";
 
   const loginForm = useForm<LoginSchema>({
     resolver: zodResolver(loginSchema),

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -1,4 +1,5 @@
 import { zodResolver } from "@hookform/resolvers/zod";
+import { LOGO_SRC } from "@/lib/constants";
 import { Alert, AlertDescription, AlertTitle } from "@evoapi/design-system/alert";
 import { Button } from "@evoapi/design-system/button";
 import { Input } from "@/components/ui/input";
@@ -11,7 +12,6 @@ import { useNavigate } from "react-router-dom";
 import { z } from "zod";
 
 import { Form, FormSelect } from "@/components/ui/form";
-import { useTheme } from "@/components/theme-provider";
 
 import { verifyCreds } from "@/lib/queries/auth/verifyCreds";
 import { verifyGoServer } from "@/lib/queries/auth/verifyGoServer";
@@ -29,13 +29,9 @@ type LoginSchema = z.infer<typeof loginSchema>;
 function Login() {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const { theme } = useTheme();
   const [loginError, setLoginError] = useState("");
   const [submitting, setSubmitting] = useState(false);
-  const logoSrc =
-    theme === "dark"
-      ? "/assets/images/evolution-logo.png"
-      : "/assets/images/evolution-logo.png";
+  const logoSrc = LOGO_SRC;
 
   const loginForm = useForm<LoginSchema>({
     resolver: zodResolver(loginSchema),


### PR DESCRIPTION
## Problem

The Manager renders a **broken logo and favicon**. The UI references its brand
assets from the project's old domain, which now return **HTTP 404** after the
rebrand:

- `https://evolution-api.com/files/evo/favicon.svg` → 404
- `https://evolution-api.com/files/evo/evolution-logo.svg` → 404
- `https://evolution-api.com/files/evo/evolution-logo-white.svg` → 404

These are referenced in:
- `index.html` (favicon)
- `src/pages/Home.tsx` (logo, ×2)
- `src/pages/Login/index.tsx`
- `src/pages/Login/LicenseCallback.tsx`
- `src/components/sidebar.tsx`

## Fix

Point all of them to the asset **already bundled in the repo** —
`public/assets/images/evolution-logo.png` (served by Vite at
`/assets/images/evolution-logo.png`) — removing the external dependency
entirely. Minimal diff, no new assets, no build changes.

## Note

The theme-aware branches (`dark` → white logo, otherwise → colored) now both
resolve to the same local asset, since only `evolution-logo.png` exists locally.
A dedicated white variant for the dark theme can be re-added later if desired;
the favicon could also use a dedicated square icon. Kept minimal here to fix the
broken images without guessing at brand assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Replace broken external logo and favicon URLs with the locally bundled logo asset across the app.

Bug Fixes:
- Fix broken logo rendering in the sidebar, home page, and login flows by using a local image asset instead of dead external URLs.
- Fix broken favicon by pointing it to the local logo image asset served by the app.