### PR TITLE
feat: add confirmation dialog to instance disconnect

### DIFF
--- a/src/pages/instance/DashboardInstance/index.tsx
+++ b/src/pages/instance/DashboardInstance/index.tsx
@@ -3,7 +3,7 @@ import { Alert, AlertTitle } from "@evoapi/design-system/alert";
 import { Avatar, AvatarImage } from "@evoapi/design-system/avatar";
 import { Button } from "@evoapi/design-system/button";
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@evoapi/design-system/card";
-import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTrigger } from "@/components/ui/dialog";
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { CircleUser, LogOut, MessageCircle, Power, QrCode, RefreshCw, Send, UsersRound } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -30,6 +30,7 @@ function DashboardInstance() {
   const [pairingCode, setPairingCode] = useState("");
   const [goQrOpen, setGoQrOpen] = useState(false);
   const [goSendOpen, setGoSendOpen] = useState(false);
+  const [logoutConfirmation, setLogoutConfirmation] = useState(false);
   const token = getToken(TOKEN_ID.TOKEN);
   const isGo = getProvider() === "go";
   const { theme } = useTheme();
@@ -126,7 +127,7 @@ function DashboardInstance() {
                 {
                   label: t("instance.dashboard.button.disconnect", { defaultValue: "Desconectar" }),
                   icon: <LogOut className="h-4 w-4" />,
-                  onClick: () => handleLogout(instance.name),
+                  onClick: () => setLogoutConfirmation(true),
                   variant: "destructive" as const,
                 },
               ]
@@ -156,9 +157,7 @@ function DashboardInstance() {
                 )}
                 <div>
                   <CardTitle className="break-all">{instance.profileName || instance.name}</CardTitle>
-                  {instance.ownerJid && (
-                    <p className="mt-1 break-all text-xs text-muted-foreground">{instance.ownerJid.split("@")[0]}</p>
-                  )}
+                  {instance.ownerJid && <p className="mt-1 break-all text-xs text-muted-foreground">{instance.ownerJid.split("@")[0]}</p>}
                 </div>
               </div>
               <InstanceStatus status={instance.connectionStatus} />
@@ -171,9 +170,7 @@ function DashboardInstance() {
 
             {!connected && (
               <Alert variant="warning" className="flex flex-wrap items-center justify-between gap-3">
-                <AlertTitle className="text-lg font-bold tracking-wide">
-                  {t("instance.dashboard.alert")}
-                </AlertTitle>
+                <AlertTitle className="text-lg font-bold tracking-wide">{t("instance.dashboard.alert")}</AlertTitle>
 
                 {isGo ? (
                   <>
@@ -195,11 +192,7 @@ function DashboardInstance() {
                       <DialogContent onCloseAutoFocus={closeQRCodePopup}>
                         <DialogHeader>{t("instance.dashboard.button.qrcode.title")}</DialogHeader>
                         <div className="flex items-center justify-center py-4">
-                          {qrCode ? (
-                            <QRCode value={qrCode} size={256} bgColor="transparent" fgColor={qrCodeColor} className="rounded-sm" />
-                          ) : (
-                            <LoadingSpinner />
-                          )}
+                          {qrCode ? <QRCode value={qrCode} size={256} bgColor="transparent" fgColor={qrCodeColor} className="rounded-sm" /> : <LoadingSpinner />}
                         </div>
                       </DialogContent>
                     </Dialog>
@@ -269,6 +262,30 @@ function DashboardInstance() {
           </Card>
         </section>
       </div>
+
+      <Dialog onOpenChange={setLogoutConfirmation} open={logoutConfirmation}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t("instance.dashboard.disconnectConfirm.title")}</DialogTitle>
+            <DialogDescription>{t("instance.dashboard.disconnectConfirm.description")}</DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <div className="flex items-center gap-4">
+              <Button onClick={() => setLogoutConfirmation(false)} size="sm" variant="outline">
+                {t("button.cancel")}
+              </Button>
+              <Button
+                onClick={() => {
+                  setLogoutConfirmation(false);
+                  handleLogout(instance.name);
+                }}
+                variant="destructive">
+                {t("instance.dashboard.button.disconnect")}
+              </Button>
+            </div>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/src/translate/languages/en-US.json
+++ b/src/translate/languages/en-US.json
@@ -352,7 +352,11 @@
       "contacts": "Contacts",
       "chats": "Chats",
       "messages": "Messages",
-      "subtitle": "Manage your instance"
+      "subtitle": "Manage your instance",
+      "disconnectConfirm": {
+        "title": "Disconnect instance?",
+        "description": "This will unlink the WhatsApp session from this instance. To reconnect you will need to scan the QR code again. Do you want to continue?"
+      }
     }
   },
   "settings": {

--- a/src/translate/languages/es-ES.json
+++ b/src/translate/languages/es-ES.json
@@ -309,7 +309,11 @@
       "contacts": "Contactos",
       "chats": "Chats",
       "messages": "Mensajes",
-      "subtitle": "Administre su instancia"
+      "subtitle": "Administre su instancia",
+      "disconnectConfirm": {
+        "title": "¿Desconectar instancia?",
+        "description": "Esto desvinculará la sesión de WhatsApp de esta instancia. Para volver a conectarla tendrás que escanear el código QR de nuevo. ¿Deseas continuar?"
+      }
     }
   },
   "settings": {

--- a/src/translate/languages/fr-FR.json
+++ b/src/translate/languages/fr-FR.json
@@ -308,7 +308,11 @@
       "contacts": "Contacts",
       "chats": "Chats",
       "messages": "Messages",
-      "subtitle": "Gérez votre instance"
+      "subtitle": "Gérez votre instance",
+      "disconnectConfirm": {
+        "title": "Déconnecter l'instance ?",
+        "description": "Cela dissociera la session WhatsApp de cette instance. Pour la reconnecter, vous devrez scanner à nouveau le code QR. Voulez-vous continuer ?"
+      }
     }
   },
   "settings": {

--- a/src/translate/languages/pt-BR.json
+++ b/src/translate/languages/pt-BR.json
@@ -309,7 +309,11 @@
       "alert": "Para conectar, escaneie o QR Code com o WhatsApp",
       "contacts": "Contatos",
       "chats": "Chats",
-      "messages": "Mensagens"
+      "messages": "Mensagens",
+      "disconnectConfirm": {
+        "title": "Desconectar instância?",
+        "description": "Isso irá desvincular a sessão do WhatsApp desta instância. Para reconectar, você precisará escanear o QR code novamente. Deseja continuar?"
+      }
     }
   },
   "settings": {


### PR DESCRIPTION
## 📋 Description

Adds a confirmation dialog to the instance **Disconnect** (logout) action on the instance dashboard.

Today, clicking **Disconnect** logs the instance out **immediately, with no confirmation**. Because this unlinks the WhatsApp session and requires re-scanning the QR code to reconnect, an accidental click is disruptive — in a multi-instance setup it can knock a live client instance offline in one click. This PR adds a simple yes/no confirmation before the logout runs.

The implementation **reuses the existing confirmation-dialog pattern** already used for the user-session logout in `src/components/header.tsx` (Radix `Dialog`), so it introduces no new dependencies or components and stays consistent with the project's conventions.

## 🔗 Related Issues

- Related to # (feature suggested in the community Discord)

## 🧪 Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🎨 Style/UI changes

## 🧪 Testing

### Test Environment
- [x] Production-like environment

### Test Cases
- [x] Manual testing completed

### Test Instructions

1. Open the dashboard of a **connected** instance (`connectionStatus === "open"`).
2. Click the **Disconnect** button.
3. A confirmation dialog appears (**"Disconnect instance?"**) with **Cancel** and **Disconnect** buttons.
4. **Cancel** closes the dialog with no side effects; **Disconnect** performs the logout as before.

Also verified locally: `npm run type-check`, `eslint`, and `prettier --check` all pass.

## 📸 Screenshots
<img width="1360" height="650" alt="Screenshot From 2026-07-22 22-16-13" src="https://github.com/user-attachments/assets/f9eb2de6-d943-4a95-ac36-b7af3df16005" />

### After
_Confirmation dialog shown before the logout runs (screenshot in PR discussion)._

## Notes

- New i18n keys `instance.dashboard.disconnectConfirm.title` / `description` added to all four locales (`pt-BR`, `en-US`, `es-ES`, `fr-FR`).
- The confirm button reuses the existing `instance.dashboard.button.disconnect` label; the cancel button reuses `button.cancel`.
- No API/behavior change beyond gating the existing logout call behind a confirmation.

## Summary by Sourcery

Add a confirmation dialog before disconnecting an instance from the dashboard to prevent accidental logouts.

New Features:
- Prompt users with a confirmation dialog when triggering the instance disconnect action on the dashboard.

Enhancements:
- Extend existing dialog UI components and translations to support the new disconnect confirmation flow across all locales.