### PR TITLE
fix(instance): refresh the QR code while the dialog is open

### DIFF
--- a/src/pages/instance/DashboardInstance/index.tsx
+++ b/src/pages/instance/DashboardInstance/index.tsx
@@ -23,11 +23,25 @@ import { getProvider, getToken, TOKEN_ID } from "@/lib/queries/token";
 import { GoQrCodeModal } from "./GoQrCodeModal";
 import { GoSendMessageModal } from "./GoSendMessageModal";
 
+/**
+ * How often the QR code shown in the dialog is refreshed.
+ *
+ * The server rotates the QR code every few seconds, but `GET /instance/connect`
+ * was only called once, when the dialog opened. The image on screen therefore
+ * went stale: users scanned a code the server had already replaced, the pairing
+ * failed, and WhatsApp blamed the phone's internet connection.
+ *
+ * Polling is safe: once the instance is in `connecting`, the endpoint returns
+ * the QR code currently held in memory and does not open a new connection.
+ */
+const QRCODE_REFRESH_INTERVAL_MS = 10_000;
+
 function DashboardInstance() {
   const { t, i18n } = useTranslation();
   const numberFormatter = new Intl.NumberFormat(i18n.language);
   const [qrCode, setQRCode] = useState<string | null>(null);
   const [pairingCode, setPairingCode] = useState("");
+  const [qrDialogOpen, setQrDialogOpen] = useState(false);
   const [goQrOpen, setGoQrOpen] = useState(false);
   const [goSendOpen, setGoSendOpen] = useState(false);
   const token = getToken(TOKEN_ID.TOKEN);
@@ -83,6 +97,22 @@ function DashboardInstance() {
       console.error("Error:", error);
     }
   };
+
+  // Keep the displayed QR code in sync with the one the server is serving.
+  useEffect(() => {
+    if (!qrDialogOpen || !instance) return;
+
+    const intervalId = setInterval(() => {
+      handleConnect(instance.name, false);
+    }, QRCODE_REFRESH_INTERVAL_MS);
+
+    return () => clearInterval(intervalId);
+  }, [qrDialogOpen, instance?.name]);
+
+  // Stop refreshing as soon as the instance is connected.
+  useEffect(() => {
+    if (instance?.connectionStatus === "open") setQrDialogOpen(false);
+  }, [instance?.connectionStatus]);
 
   const closeQRCodePopup = async () => {
     setQRCode(null);
@@ -185,7 +215,7 @@ function DashboardInstance() {
                   </>
                 ) : (
                   <div className="flex flex-wrap gap-2">
-                    <Dialog>
+                    <Dialog open={qrDialogOpen} onOpenChange={setQrDialogOpen}>
                       <DialogTrigger onClick={() => handleConnect(instance.name, false)} asChild>
                         <Button>
                           <QrCode className="mr-2 h-4 w-4" />


### PR DESCRIPTION
## Problem

The dashboard requests a QR code once, when the dialog opens, and never again:

```tsx
const handleConnect = async (instanceName, wantPairing) => {
  const data = await connect({ instanceName, token });
  setQRCode(data.code);   // set once, never updated
};
```

The server, however, keeps rotating the pairing code every few seconds. From the
second rotation onwards, the image on screen is a code the server has already
discarded, and there is nothing on the page telling the user that.

What the user sees when they scan a stale code is not a QR error. The phone shows
*"logging in…"* for a while and then:

> **Could not log in.** Check your phone's internet connection and scan the QR code again.

So the failure is reported as a network problem on the phone, which sends people
looking in the wrong place. On our own deployment this made pairing feel
unreliable for months, across several instances.

## Evidence

Server log for one pairing attempt, with the code counter already at 3 while the
dialog still displayed the first one:

```
17:24:50  { instance: Mundo Veneco, pairingCode: null, qrcodeCount: 3 }
17:24:57  connection: 'close', statusCode: 515
```

## Fix

Poll `GET /instance/connect` every 10 seconds while the dialog is open.

This does not create extra connections. Once the instance is in `connecting`,
the endpoint returns the code currently held in memory and opens nothing:

```js
o == "connecting" ? t.qrCode
: o == "close"    ? (await t.connectToWhatsapp(e), await delay(2000), t.qrCode)
```

Only the `close` branch starts a connection, and by the time the interval fires
the first time the instance has already moved to `connecting`.

The interval is cleared when the dialog closes, and a second effect closes the
dialog as soon as the instance reports `open`, so polling stops on success
instead of running until the user dismisses the modal.

## Notes

- 10 s is shorter than the server's rotation window, so the displayed code is
  never more than one poll behind.
- The dialog is now controlled (`open` / `onOpenChange`) because the effect needs
  to know whether it is visible.
- `npm run type-check` and `eslint` pass. `prettier --check` reports this file as
  unformatted both before and after the change, so it was left untouched rather
  than mixing a whole-file reformat into the diff.

## Summary by Sourcery

Refresh the instance QR code periodically while the connection dialog is open to prevent users from scanning stale codes.

Bug Fixes:
- Fix stale QR codes during instance pairing by polling the connect endpoint while the QR dialog is open.

Enhancements:
- Control the QR dialog visibility via component state so it can automatically close once the instance connection is open.