### PR TITLE
fix(instance): do not open a second connection on repeated clicks

### DIFF
--- a/src/pages/instance/DashboardInstance/index.tsx
+++ b/src/pages/instance/DashboardInstance/index.tsx
@@ -5,7 +5,7 @@ import { Button } from "@evoapi/design-system/button";
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@evoapi/design-system/card";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTrigger } from "@/components/ui/dialog";
 import { CircleUser, LogOut, MessageCircle, Power, QrCode, RefreshCw, Send, UsersRound } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import QRCode from "react-qr-code";
 
@@ -28,8 +28,12 @@ function DashboardInstance() {
   const numberFormatter = new Intl.NumberFormat(i18n.language);
   const [qrCode, setQRCode] = useState<string | null>(null);
   const [pairingCode, setPairingCode] = useState("");
+  const [isConnecting, setIsConnecting] = useState(false);
   const [goQrOpen, setGoQrOpen] = useState(false);
   const [goSendOpen, setGoSendOpen] = useState(false);
+  // Ref instead of state: it has to be readable synchronously, before React
+  // has had a chance to re-render, or two fast clicks both pass the check.
+  const connectInFlight = useRef(false);
   const token = getToken(TOKEN_ID.TOKEN);
   const isGo = getProvider() === "go";
   const { theme } = useTheme();
@@ -67,7 +71,19 @@ function DashboardInstance() {
     }
   };
 
+  /**
+   * Ask the server for a QR code or a pairing code.
+   *
+   * Only one request may be in flight at a time. When the instance is closed,
+   * GET /instance/connect opens a brand new WhatsApp connection, so clicking
+   * the button twice left two sockets racing for the same instance: the phone
+   * would scan the code of one while the other overwrote the pairing state.
+   */
   const handleConnect = async (instanceName: string, wantPairing: boolean) => {
+    if (connectInFlight.current) return;
+    connectInFlight.current = true;
+    setIsConnecting(true);
+
     try {
       setQRCode(null);
       if (!token) return console.error("Token not found.");
@@ -81,6 +97,9 @@ function DashboardInstance() {
       }
     } catch (error) {
       console.error("Error:", error);
+    } finally {
+      connectInFlight.current = false;
+      setIsConnecting(false);
     }
   };
 
@@ -187,7 +206,7 @@ function DashboardInstance() {
                   <div className="flex flex-wrap gap-2">
                     <Dialog>
                       <DialogTrigger onClick={() => handleConnect(instance.name, false)} asChild>
-                        <Button>
+                        <Button disabled={isConnecting}>
                           <QrCode className="mr-2 h-4 w-4" />
                           {t("instance.dashboard.button.qrcode.label")}
                         </Button>
@@ -207,7 +226,7 @@ function DashboardInstance() {
                     {instance.number && (
                       <Dialog>
                         <DialogTrigger asChild>
-                          <Button variant="outline" onClick={() => handleConnect(instance.name, true)}>
+                          <Button variant="outline" disabled={isConnecting} onClick={() => handleConnect(instance.name, true)}>
                             {t("instance.dashboard.button.pairingCode.label")}
                           </Button>
                         </DialogTrigger>


### PR DESCRIPTION
## Problem

The QR code and pairing code buttons call `handleConnect` with no guard against
repeated clicks:

```tsx
<DialogTrigger onClick={() => handleConnect(instance.name, false)} asChild>
  <Button>…</Button>
</DialogTrigger>
```

That matters because `GET /instance/connect` is not a read-only endpoint. When
the instance is closed it opens a new WhatsApp connection:

```js
o == "open"       ? await this.connectionState({ instanceName: s })
: o == "connecting" ? t.qrCode
: o == "close"    ? (await t.connectToWhatsapp(e), await delay(2000), t.qrCode)
```

There is a 2-second delay inside that branch before anything is returned, and
the button stays enabled the whole time. Clicking again during that window
starts a second connection for the same instance, so two sockets end up racing:
each produces its own QR code, and the one the user is looking at may be
invalidated by the other. This is easy to trigger by accident, because when the
first attempt seems slow the natural reaction is to click again.

## Fix

Allow a single request in flight at a time, and disable the buttons while it
runs.

The guard is a `useRef` rather than state on purpose: two fast clicks would both
read the same stale value from state before React re-renders, and both would
pass the check. A ref is updated synchronously, so the second click is rejected.

`isConnecting` state is still used for the `disabled` prop, which gives the user
visible feedback instead of leaving them wondering whether the click registered.

## Notes

- Applies to both entry points, QR code and pairing code, since they share the
  same handler.
- The flag is reset in a `finally` block, so a failed request does not leave the
  buttons permanently disabled.
- `npm run type-check` and `eslint` pass. `prettier --check` reports this file as
  unformatted both before and after the change, so it was left untouched rather
  than mixing a whole-file reformat into the diff.

## Summary by Sourcery

Guard instance connection requests so only one connect operation can run at a time and reflect this state in the UI.

Bug Fixes:
- Prevent multiple WhatsApp connections and racing QR codes caused by repeated clicks on the connect actions.

Enhancements:
- Disable QR code and pairing code buttons while a connection request is in progress to provide clear feedback and avoid duplicate actions.